### PR TITLE
set shutdown flag to true in stop() method before waiting for empty queu...

### DIFF
--- a/src/main/java/com/netflix/logging/messaging/MessageBatcher.java
+++ b/src/main/java/com/netflix/logging/messaging/MessageBatcher.java
@@ -115,7 +115,7 @@ public class MessageBatcher<T> {
 
     protected Counter queueOverflowCounter;
 
-    private boolean isShutDown;
+    private volatile boolean isShutDown;
 
     private AtomicLong numberAdded = new AtomicLong();
 
@@ -344,7 +344,13 @@ public class MessageBatcher<T> {
      * 
      */
     public void stop() {
-
+        /*
+         * Sets the shutdown flag. Future sends to the batcher are not accepted.
+         * The processors wait for the current messages in the queue and with
+         * the processor or collector to complete
+         */
+        isShutDown = true;
+        
         int waitTimeinMillis = CONFIGURATION.getBatcherWaitTimeBeforeShutdown(this.name);
         long timeToWait = waitTimeinMillis + System.currentTimeMillis();
         while ((queue.size() > 0 || batch.size() > 0)
@@ -366,13 +372,6 @@ public class MessageBatcher<T> {
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-        /*
-         * Sets the shutdown flag. Future sends to the batcher are not accepted.
-         * The processors wait for the current messages in the queue and with
-         * the processor or collector to complete
-         */
-        isShutDown = true;
-
     }
 
     /**


### PR DESCRIPTION
...e

After a quiet period the batch size and queue size might be empty thus ending the while loop but some new message had a chance to be added to the queue before the flag was set. 
Thus calling the stop() method from a different thread than the one calling process was not threadsafe!
