### PR TITLE
Changed message processor thread to daemon thread

### DIFF
--- a/src/main/java/com/netflix/logging/messaging/MessageBatcher.java
+++ b/src/main/java/com/netflix/logging/messaging/MessageBatcher.java
@@ -581,7 +581,7 @@ public class MessageBatcher<T> {
         int keepAliveTime = CONFIGURATION.getBatcherThreadKeepAliveTime(this.name);
 
         ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setDaemon(false).setNameFormat(this.name + "-process").build();
+                .setDaemon(true).setNameFormat(this.name + "-process").build();
 
         this.processor = new ThreadPoolExecutor(minThreads, maxThreads,
                 keepAliveTime, TimeUnit.SECONDS, new SynchronousQueue(),


### PR DESCRIPTION
I'm not sure why message batcher's processing thread is set to non-daemon thread. This is a background thread and it should exit when JVM does. Since a MessageBatcher does not have a lifecycle to manage, we should set the processor thread to daemon thread instead. 
