### PR TITLE
Expose constructor to subclasses

### DIFF
--- a/src/main/java/com/netflix/blitz4j/LoggingConfiguration.java
+++ b/src/main/java/com/netflix/blitz4j/LoggingConfiguration.java
@@ -96,7 +96,7 @@ public class LoggingConfiguration implements PropertyListener {
 
     private static LoggingConfiguration instance = new LoggingConfiguration();
 
-    private LoggingConfiguration() {
+    protected LoggingConfiguration() {
         ThreadFactory threadFactory = new ThreadFactoryBuilder()
         .setDaemon(false).setNameFormat("DynamicLog4jListener").build();
 


### PR DESCRIPTION
To give users of NetflixOSS a chance to modify the LoggingConfiguration
(e.g. not use log4j) we need to expose at least a constructor, so that
a subclass can be created that overrides some of the default behaviour.
More could be done to make the logging more flexible, but if we start
with this then one can make some progress.
