### PR TITLE
Only load properties with the log4j prefix

### DIFF
--- a/src/main/java/com/netflix/blitz4j/LoggingConfiguration.java
+++ b/src/main/java/com/netflix/blitz4j/LoggingConfiguration.java
@@ -354,7 +354,8 @@ public class LoggingConfiguration implements PropertyListener {
 
     /**
      * Set a snapshot of all LOG4J properties and reconfigure if properties have been
-     * changed.  
+     * changed. This assumes that the Properties being set here has already been filtered
+     * to only properties starting with LOG4J_PREFIX.
      * @param props Complete set of ALL log4j configuration properties including all
      *              appenders and log level overrides
      */

--- a/src/main/java/com/netflix/blitz4j/LoggingConfiguration.java
+++ b/src/main/java/com/netflix/blitz4j/LoggingConfiguration.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.configuration.AbstractConfiguration;
-import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.LogManager;

--- a/src/main/java/com/netflix/blitz4j/LoggingConfiguration.java
+++ b/src/main/java/com/netflix/blitz4j/LoggingConfiguration.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -28,8 +30,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.helpers.Loader;
@@ -318,7 +322,19 @@ public class LoggingConfiguration implements PropertyListener {
      * com.netflix.config.PropertyListener#configSourceLoaded(java.lang.Object)
      */
     public void configSourceLoaded(Object source) {
-        Properties props = ConfigurationConverter.getProperties(ConfigurationManager.getConfigInstance());
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        Properties props = new Properties();
+
+        char delimiter = config.getListDelimiter();
+
+        for (Iterator<String> keys = config.getKeys(LOG4J_PREFIX); keys.hasNext();) {
+            String key = keys.next();
+            List<Object> list = config.getList(key);
+
+            // turn the list into a string
+            props.setProperty(key, StringUtils.join(list.iterator(), delimiter));
+        }
+
         reconfigure(props);
     }
 
@@ -347,11 +363,9 @@ public class LoggingConfiguration implements PropertyListener {
         // set of original initialization properties
         Properties newOverrideProps = new Properties();
         for (Entry<Object, Object> prop : props.entrySet()) {
-            if (isLog4JProperty(prop.getKey().toString())) {
-                Object initialValue = initialProps.get(prop.getKey());
-                if (initialValue == null || !initialValue.equals(prop.getValue())) {
-                    newOverrideProps.put(prop.getKey(), prop.getValue());
-                }
+            Object initialValue = initialProps.get(prop.getKey());
+            if (initialValue == null || !initialValue.equals(prop.getValue())) {
+                newOverrideProps.put(prop.getKey(), prop.getValue());
             }
         }
         


### PR DESCRIPTION
As part of the fast property instrumentation effort, we are modifying locations in code that iterate over all properties in order to reduce the amount of noise.

Blitz4j only reads log4j-prefixed properties for overrides, so we change the code here to only read those, instead of first reading then filtering.

This copies up the method from Apache commons configuration https://github.com/apache/commons-configuration/blob/CONFIGURATION_1_10/src/main/java/org/apache/commons/configuration/ConfigurationConverter.java#L105