### PR TITLE
refactor: Change GitHub Action version to address deprecation of v1/v2

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -21,14 +21,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
           restore-keys: |
             - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -14,14 +14,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
           restore-keys: |
             - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -16,13 +16,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: |
             ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: |


### PR DESCRIPTION
Starting February 1st, 2025, Github is closing down v1-v2 of actions/cache (read more about it in this [changelog announcement](https://app.github.media/e/er?s=88570519&lid=6815&elqTrackId=08a5e2ee0de44b669cfee44c72a218f2&elq=553eec1a7c454e1f86dace7dd5ce9583&elqaid=4282&elqat=1&elqak=8AF5E7AAA12E3C7C230E5849DC6FF5707A505F45E589E4FD0E873A034D6DD7B23D08)) as well as all previous versions of the @actions/cache package in actions/toolkit. Attempting to use a version of the @actions/cache package or actions/cache after the announced deprecation date will result in a workflow failure. If you are pinned to a specific version or SHA of the cache action, your workflows will also fail after February 1st.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.github.ChangeActionVersion?organizationId=TmV0ZmxpeA%3D%3D#defaults=W3sidmFsdWUiOiJhY3Rpb25zL2NhY2hlIiwibmFtZSI6ImFjdGlvbiJ9LHsidmFsdWUiOiJ2NCIsIm5hbWUiOiJ2ZXJzaW9uIn1d